### PR TITLE
PAPP-23257: removing biased language from the action name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v1.5
+    rev: v1.6
     hooks:
     -   id: org-hook
     -   id: package-app-dependencies

--- a/readme.html
+++ b/readme.html
@@ -2,8 +2,8 @@
 <p>The ThreatX Phantom App allows automated enforcement actions, including:</p>
 <ul>
 <li>temporarily blocking/unblocking IPs</li>
-<li>blacklisting/unblacklisting IPs</li>
-<li>whitelisting/unwhitelisting IPs</li>
+<li>Add/Remove IPs in denylist</li>
+<li>Add/Remove IPs in allowlist</li>
 </ul>
 <p>In addition, valuable investigative actions allow you to pull realtime Entity information, including:</p>
 <ul>

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 [comment]: # "Auto-generated SOAR connector documentation"
 # ThreatX
 
-Publisher: ThreatX  
-Connector Version: 1\.0\.1  
-Product Vendor: ThreatX  
-Product Name: WAF  
-Product Version Supported (regex): "\.\*"  
-Minimum Product Version: 4\.2\.7532  
+Publisher: ThreatX
+Connector Version: 1\.0\.1
+Product Vendor: ThreatX
+Product Name: WAF
+Product Version Supported (regex): "\.\*"
+Minimum Product Version: 4\.2\.7532
 
 This app implements investigative and enforcement actions on the ThreatX NG WAF platform
 
@@ -14,8 +14,8 @@ This app implements investigative and enforcement actions on the ThreatX NG WAF 
 The ThreatX Phantom App allows automated enforcement actions, including:
 
 -   temporarily blocking/unblocking IPs
--   blacklisting/unblacklisting IPs
--   whitelisting/unwhitelisting IPs
+-   Add/Remove IPs in denylist
+-   Add/Remove IPs in allowlist
 
 In addition, valuable investigative actions allow you to pull realtime Entity information,
 including:
@@ -37,24 +37,24 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **customer\_name** |  required  | string | Customer Name provided by the ThreatX SOC
 **api\_key** |  required  | password | API Key provided by the ThreatX SOC
 
-### Supported Actions  
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration  
-[block ip](#action-block-ip) - Block an IP  
-[unblock ip](#action-unblock-ip) - Unblock an IP  
-[blacklist ip](#action-blacklist-ip) - Add an IP to the Blacklist  
-[blacklist ip](#action-blacklist-ip) - Remove an IP from the Blacklist  
-[whitelist ip](#action-whitelist-ip) - Add an IP to the Whitelist  
-[whitelist ip](#action-whitelist-ip) - Remove an IP from the Whitelist  
-[get entities](#action-get-entities) - Get high\-level Entity information  
-[get entity ips](#action-get-entity-ips) - Get all Entity IP addresses  
-[get entity risk](#action-get-entity-risk) - Get the latest Entity risk score  
-[get entity notes](#action-get-entity-notes) - Get the Entity notes  
-[new entity note](#action-new-entity-note) - Add a new note for the Entity  
+### Supported Actions
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration
+[block ip](#action-block-ip) - Block an IP
+[unblock ip](#action-unblock-ip) - Unblock an IP
+[add denylist ip](#action-add-denylist-ip) - Add an IP to the Denylist
+[remove denylist ip](#action-remove-denylist-ip) - Remove an IP from the Denylist
+[app allowlist ip](#action-add-allowlist-ip) - Add an IP to the Allowlist
+[remove allowlist ip](#action-remove-allowlist-ip) - Remove an IP from the Allowlist
+[get entities](#action-get-entities) - Get high\-level Entity information
+[get entity ips](#action-get-entity-ips) - Get all Entity IP addresses
+[get entity risk](#action-get-entity-risk) - Get the latest Entity risk score
+[get entity notes](#action-get-entity-notes) - Get the Entity notes
+[new entity note](#action-new-entity-note) - Add a new note for the Entity
 
 ## action: 'test connectivity'
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test**  
+Type: **test**
 Read only: **True**
 
 This action will attempt to pull the user list from the ThreatX platform to test connectivity\.
@@ -63,12 +63,12 @@ This action will attempt to pull the user list from the ThreatX platform to test
 No parameters are required for this action
 
 #### Action Output
-No Output  
+No Output
 
 ## action: 'block ip'
 Block an IP
 
-Type: **contain**  
+Type: **contain**
 Read only: **False**
 
 Perform a temporary block on an IP
@@ -76,23 +76,23 @@ Perform a temporary block on an IP
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP to block | string |  `ip` 
+**ip** |  required  | IP to block | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.data\.\*\.Ok | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.data\.\*\.Ok | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'unblock ip'
 Unblock an IP
 
-Type: **correct**  
+Type: **correct**
 Read only: **False**
 
 Unblock an IP that has been temporarily blocked
@@ -100,119 +100,119 @@ Unblock an IP that has been temporarily blocked
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP to unblock | string |  `ip` 
+**ip** |  required  | IP to unblock | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.data\.\*\.Ok | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.data\.\*\.Ok | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
-## action: 'blacklist ip'
-Add an IP to the Blacklist
+## action: 'denylist ip'
+Add an IP to the Denylist
 
-Type: **contain**  
+Type: **contain**
 Read only: **False**
 
-This action adds an IP to the Blacklist as a permanent block\.
+This action adds an IP to the Denylist as a permanent block\.
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP to add to the Blacklist | string |  `ip` 
+**ip** |  required  | IP to add to the Denylist | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.data\.\*\.Ok | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.data\.\*\.Ok | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
-## action: 'blacklist ip'
-Remove an IP from the Blacklist
+## action: 'denylist ip'
+Remove an IP from the Denylist
 
-Type: **correct**  
+Type: **correct**
 Read only: **False**
 
-This action removes an IP from the Blacklist so it will no longer be blocked\.
+This action removes an IP from the Denylist so it will no longer be blocked\.
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP to remove from the Blacklist | string |  `ip` 
+**ip** |  required  | IP to remove from the Denylist | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.data\.\*\.Ok | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.data\.\*\.Ok | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
-## action: 'whitelist ip'
-Add an IP to the Whitelist
+## action: 'allowlist ip'
+Add an IP to the Allowlist
 
-Type: **correct**  
+Type: **correct**
 Read only: **False**
 
-This action adds an IP to the Whitelist so it will never be blocked\.
+This action adds an IP to the Allowlist so it will never be blocked\.
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP to add to the Whitelist | string |  `ip` 
+**ip** |  required  | IP to add to the Allowlist | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.data\.\*\.Ok | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.data\.\*\.Ok | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
-## action: 'whitelist ip'
-Remove an IP from the Whitelist
+## action: 'allowlist ip'
+Remove an IP from the Allowlist
 
-Type: **correct**  
+Type: **correct**
 Read only: **False**
 
-This action removes an IP from the Whitelist so it can become blocked\.
+This action removes an IP from the Allowlist so it can become blocked\.
 
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**ip** |  required  | IP to remove from the Whitelist | string |  `ip` 
+**ip** |  required  | IP to remove from the Allowlist | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.ip | string |  `ip` 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.data\.\*\.Ok | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.parameter\.ip | string |  `ip`
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.data\.\*\.Ok | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'get entities'
 Get high\-level Entity information
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 This action queries the ThreatX platform for Entities seen by Entity Name, Entity ID, or Entity IP\. The query result provides detailed metadata about the Entity and its lower\-level Actors\. It is often helpful to use this action to query by Entity IP or Entity Name to get the Entity ID, which can be used in other Entity queries\. \(e\.g\. Entity Risk and Entity Notes\)
@@ -220,47 +220,47 @@ This action queries the ThreatX platform for Entities seen by Entity Name, Entit
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**entity\_name** |  optional  | Name of the Entity | string |  `threatx entity name` 
-**entity\_id** |  optional  | ID hash of the Entity | string |  `threatx entity id` 
-**entity\_ip** |  optional  | IP address of the Entity | string |  `ip` 
+**entity\_name** |  optional  | Name of the Entity | string |  `threatx entity name`
+**entity\_id** |  optional  | ID hash of the Entity | string |  `threatx entity id`
+**entity\_ip** |  optional  | IP address of the Entity | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.data\.\*\.entity\_name | string |  `threatx entity name` 
-action\_result\.data\.\*\.id | string |  `threatx entity id` 
-action\_result\.data\.\*\.actors\.0\.ip\_address | string |  `ip` 
-action\_result\.data\.\*\.actors\.0\.geo\_country | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.status | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric | 
-action\_result\.data\.\*\.actors\.\*\.hash | numeric | 
-action\_result\.data\.\*\.actors\.\*\.interval\_time\_stop | numeric | 
-action\_result\.data\.\*\.actors\.\*\.is\_embargoed | boolean | 
-action\_result\.data\.\*\.actors\.\*\.state | string | 
-action\_result\.data\.\*\.actors\.\*\.reputation | numeric | 
-action\_result\.data\.\*\.actors\.\*\.geo\_coordinates\.y | numeric | 
-action\_result\.data\.\*\.actors\.\*\.geo\_coordinates\.x | numeric | 
-action\_result\.data\.\*\.actors\.\*\.state\_update | string | 
-action\_result\.data\.\*\.actors\.\*\.is\_tor\_exit | boolean | 
-action\_result\.data\.\*\.actors\.\*\.fingerprint\.count | numeric | 
-action\_result\.data\.\*\.actors\.\*\.fingerprint\.js\_fingerprint | string | 
-action\_result\.data\.\*\.actors\.\*\.fingerprint\.cookie | string | 
-action\_result\.data\.\*\.actors\.\*\.fingerprint\.user\_agent | string | 
-action\_result\.data\.\*\.actors\.\*\.fingerprint\.last\_seen | numeric | 
-action\_result\.data\.\*\.actors\.\*\.seq\_blocks | string | 
-action\_result\.data\.\*\.actors\.\*\.interval\_time\_start | numeric | 
-action\_result\.data\.\*\.actors\.\*\.entity\_hash | string | 
-action\_result\.parameter\.entity\_name | string |  `threatx entity name` 
-action\_result\.parameter\.entity\_ip | string |  `ip` 
-action\_result\.parameter\.entity\_id | string |  `threatx entity id`   
+action\_result\.data\.\*\.entity\_name | string |  `threatx entity name`
+action\_result\.data\.\*\.id | string |  `threatx entity id`
+action\_result\.data\.\*\.actors\.0\.ip\_address | string |  `ip`
+action\_result\.data\.\*\.actors\.0\.geo\_country | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.status | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
+action\_result\.data\.\*\.actors\.\*\.hash | numeric |
+action\_result\.data\.\*\.actors\.\*\.interval\_time\_stop | numeric |
+action\_result\.data\.\*\.actors\.\*\.is\_embargoed | boolean |
+action\_result\.data\.\*\.actors\.\*\.state | string |
+action\_result\.data\.\*\.actors\.\*\.reputation | numeric |
+action\_result\.data\.\*\.actors\.\*\.geo\_coordinates\.y | numeric |
+action\_result\.data\.\*\.actors\.\*\.geo\_coordinates\.x | numeric |
+action\_result\.data\.\*\.actors\.\*\.state\_update | string |
+action\_result\.data\.\*\.actors\.\*\.is\_tor\_exit | boolean |
+action\_result\.data\.\*\.actors\.\*\.fingerprint\.count | numeric |
+action\_result\.data\.\*\.actors\.\*\.fingerprint\.js\_fingerprint | string |
+action\_result\.data\.\*\.actors\.\*\.fingerprint\.cookie | string |
+action\_result\.data\.\*\.actors\.\*\.fingerprint\.user\_agent | string |
+action\_result\.data\.\*\.actors\.\*\.fingerprint\.last\_seen | numeric |
+action\_result\.data\.\*\.actors\.\*\.seq\_blocks | string |
+action\_result\.data\.\*\.actors\.\*\.interval\_time\_start | numeric |
+action\_result\.data\.\*\.actors\.\*\.entity\_hash | string |
+action\_result\.parameter\.entity\_name | string |  `threatx entity name`
+action\_result\.parameter\.entity\_ip | string |  `ip`
+action\_result\.parameter\.entity\_id | string |  `threatx entity id`
 
 ## action: 'get entity ips'
 Get all Entity IP addresses
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 This action queries the ThreatX platform for Entities seen by Entity Name, Entity ID, or Entity IP\. The query result provides a list of all IP addresses associated with all of the Entities returned\.
@@ -268,30 +268,30 @@ This action queries the ThreatX platform for Entities seen by Entity Name, Entit
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**entity\_name** |  optional  | Name of the Entity | string |  `threatx entity name` 
-**entity\_id** |  optional  | ID hash of the Entity | string |  `threatx entity id` 
-**entity\_ip** |  optional  | IP address of the Entity | string |  `ip` 
+**entity\_name** |  optional  | Name of the Entity | string |  `threatx entity name`
+**entity\_id** |  optional  | ID hash of the Entity | string |  `threatx entity id`
+**entity\_ip** |  optional  | IP address of the Entity | string |  `ip`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.data\.\*\.entity\_name | string |  `threatx entity name` 
-action\_result\.data\.\*\.entity\_id | string |  `threatx entity id` 
-action\_result\.data\.\*\.ip | string |  `ip` 
-action\_result\.data\.\*\.geo\_country | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.status | string | 
-action\_result\.parameter\.entity\_name | string |  `threatx entity name` 
-action\_result\.parameter\.entity\_ip | string |  `ip` 
-action\_result\.parameter\.entity\_id | string |  `threatx entity id` 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.data\.\*\.entity\_name | string |  `threatx entity name`
+action\_result\.data\.\*\.entity\_id | string |  `threatx entity id`
+action\_result\.data\.\*\.ip | string |  `ip`
+action\_result\.data\.\*\.geo\_country | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.status | string |
+action\_result\.parameter\.entity\_name | string |  `threatx entity name`
+action\_result\.parameter\.entity\_ip | string |  `ip`
+action\_result\.parameter\.entity\_id | string |  `threatx entity id`
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'get entity risk'
 Get the latest Entity risk score
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 This action queries the ThreatX platform for Entities seen by Entity ID\. The query result provides the current risk score for the Entity\.
@@ -299,26 +299,26 @@ This action queries the ThreatX platform for Entities seen by Entity ID\. The qu
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**entity\_id** |  required  | ID hash of the Entity | string |  `threatx entity id` 
+**entity\_id** |  required  | ID hash of the Entity | string |  `threatx entity id`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.data\.\*\.entity\_id | string |  `threatx entity id` 
-action\_result\.data\.\*\.risk | numeric | 
-action\_result\.data\.\*\.pretty\_time | string | 
-action\_result\.data\.\*\.timestamp | numeric | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.status | string | 
-action\_result\.parameter\.entity\_id | string |  `threatx entity id` 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.data\.\*\.entity\_id | string |  `threatx entity id`
+action\_result\.data\.\*\.risk | numeric |
+action\_result\.data\.\*\.pretty\_time | string |
+action\_result\.data\.\*\.timestamp | numeric |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.status | string |
+action\_result\.parameter\.entity\_id | string |  `threatx entity id`
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'get entity notes'
 Get the Entity notes
 
-Type: **investigate**  
+Type: **investigate**
 Read only: **True**
 
 This action queries the ThreatX platform for Entities seen by Entity ID\. The query result provides all notes associated with the Entity\.
@@ -326,27 +326,27 @@ This action queries the ThreatX platform for Entities seen by Entity ID\. The qu
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**entity\_id** |  required  | ID hash of the Entity | string |  `threatx entity id` 
+**entity\_id** |  required  | ID hash of the Entity | string |  `threatx entity id`
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.data\.\*\.content | string | 
-action\_result\.data\.\*\.username | string |  `email` 
-action\_result\.data\.\*\.pretty\_time | string | 
-action\_result\.data\.\*\.timestamp | numeric | 
-action\_result\.data\.\*\.entity\_id | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-action\_result\.status | string | 
-action\_result\.parameter\.entity\_id | string |  `threatx entity id` 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric |   
+action\_result\.data\.\*\.content | string |
+action\_result\.data\.\*\.username | string |  `email`
+action\_result\.data\.\*\.pretty\_time | string |
+action\_result\.data\.\*\.timestamp | numeric |
+action\_result\.data\.\*\.entity\_id | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+action\_result\.status | string |
+action\_result\.parameter\.entity\_id | string |  `threatx entity id`
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
 
 ## action: 'new entity note'
 Add a new note for the Entity
 
-Type: **generic**  
+Type: **generic**
 Read only: **False**
 
 This action adds a new note to an Entity\. The Entity is specified by the Entity ID\.
@@ -354,17 +354,17 @@ This action adds a new note to an Entity\. The Entity is specified by the Entity
 #### Action Parameters
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**entity\_id** |  required  | ID hash of the Entity | string |  `threatx entity id` 
-**content** |  required  | Content of the note | string | 
+**entity\_id** |  required  | ID hash of the Entity | string |  `threatx entity id`
+**content** |  required  | Content of the note | string |
 
 #### Action Output
 DATA PATH | TYPE | CONTAINS
 --------- | ---- | --------
-action\_result\.parameter\.entity\_id | string |  `threatx entity id` 
-action\_result\.parameter\.content | string | 
-action\_result\.status | string | 
-action\_result\.message | string | 
-action\_result\.summary\.result | string | 
-summary\.total\_objects | numeric | 
-summary\.total\_objects\_successful | numeric | 
-action\_result\.data\.\*\.Ok | string | 
+action\_result\.parameter\.entity\_id | string |  `threatx entity id`
+action\_result\.parameter\.content | string |
+action\_result\.status | string |
+action\_result\.message | string |
+action\_result\.summary\.result | string |
+summary\.total\_objects | numeric |
+summary\.total\_objects\_successful | numeric |
+action\_result\.data\.\*\.Ok | string |

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Removing biased language action name from the app [PAPP-23257]

--- a/threatx.json
+++ b/threatx.json
@@ -197,15 +197,15 @@
             "versions": "EQ(*)"
         },
         {
-            "action": "blacklist ip",
-            "identifier": "new_blacklist_ip",
-            "description": "Add an IP to the Blacklist",
-            "verbose": "This action adds an IP to the Blacklist as a permanent block.",
+            "action": "add denylist ip",
+            "identifier": "new_denylist_ip",
+            "description": "Add an IP to the Denylist",
+            "verbose": "This action adds an IP to the Denylist as a permanent block.",
             "type": "contain",
             "read_only": false,
             "parameters": {
                 "ip": {
-                    "description": "IP to add to the Blacklist",
+                    "description": "IP to add to the Denylist",
                     "data_type": "string",
                     "required": true,
                     "primary": true,
@@ -250,7 +250,7 @@
                     "data_path": "action_result.data.*.Ok",
                     "data_type": "string",
                     "example_values": [
-                        "Blacklist entry for ip 8.8.8.8 added"
+                        "Denylist entry for ip 8.8.8.8 added"
                     ]
                 },
                 {
@@ -274,15 +274,15 @@
             "versions": "EQ(*)"
         },
         {
-            "action": "blacklist ip",
-            "identifier": "remove_blacklist_ip",
-            "description": "Remove an IP from the Blacklist",
-            "verbose": "This action removes an IP from the Blacklist so it will no longer be blocked.",
+            "action": "remove denylist ip",
+            "identifier": "remove_denylist_ip",
+            "description": "Remove an IP from the Denylist",
+            "verbose": "This action removes an IP from the Denylist so it will no longer be blocked.",
             "type": "correct",
             "read_only": false,
             "parameters": {
                 "ip": {
-                    "description": "IP to remove from the Blacklist",
+                    "description": "IP to remove from the Denylist",
                     "data_type": "string",
                     "required": true,
                     "primary": true,
@@ -327,7 +327,7 @@
                     "data_path": "action_result.data.*.Ok",
                     "data_type": "string",
                     "example_values": [
-                        "Blacklist entry for ip 8.8.8.8 removed"
+                        "Denylist entry for ip 8.8.8.8 removed"
                     ]
                 },
                 {
@@ -351,15 +351,15 @@
             "versions": "EQ(*)"
         },
         {
-            "action": "whitelist ip",
-            "identifier": "new_whitelist_ip",
-            "description": "Add an IP to the Whitelist",
-            "verbose": "This action adds an IP to the Whitelist so it will never be blocked.",
+            "action": "add allowlist ip",
+            "identifier": "new_allowlist_ip",
+            "description": "Add an IP to the Allowlist",
+            "verbose": "This action adds an IP to the Allowlist so it will never be blocked.",
             "type": "correct",
             "read_only": false,
             "parameters": {
                 "ip": {
-                    "description": "IP to add to the Whitelist",
+                    "description": "IP to add to the Allowlist",
                     "data_type": "string",
                     "required": true,
                     "primary": true,
@@ -404,7 +404,7 @@
                     "data_path": "action_result.data.*.Ok",
                     "data_type": "string",
                     "example_values": [
-                        "Whitelist entry for ip 8.8.8.8 added"
+                        "Allowlist entry for ip 8.8.8.8 added"
                     ]
                 },
                 {
@@ -428,15 +428,15 @@
             "versions": "EQ(*)"
         },
         {
-            "action": "whitelist ip",
-            "identifier": "remove_whitelist_ip",
-            "description": "Remove an IP from the Whitelist",
-            "verbose": "This action removes an IP from the Whitelist so it can become blocked.",
+            "action": "remove allowlist ip",
+            "identifier": "remove_allowlist_ip",
+            "description": "Remove an IP from the Allowlist",
+            "verbose": "This action removes an IP from the Allowlist so it can become blocked.",
             "type": "correct",
             "read_only": false,
             "parameters": {
                 "ip": {
-                    "description": "IP to remove from the Whitelist",
+                    "description": "IP to remove from the Allowlist",
                     "data_type": "string",
                     "required": true,
                     "primary": true,
@@ -481,7 +481,7 @@
                     "data_path": "action_result.data.*.Ok",
                     "data_type": "string",
                     "example_values": [
-                        "Whitelist entry for ip 8.8.8.8 removed"
+                        "Allowlist entry for ip 8.8.8.8 removed"
                     ]
                 },
                 {

--- a/threatx_connector.py
+++ b/threatx_connector.py
@@ -1,12 +1,13 @@
+import ipaddress
+import json
 import time
 from operator import itemgetter
-import ipaddress
+
 import phantom.app as phantom
-from phantom.base_connector import BaseConnector
-from phantom.action_result import ActionResult
 import requests
-import json
 from bs4 import BeautifulSoup
+from phantom.action_result import ActionResult
+from phantom.base_connector import BaseConnector
 
 # ThreatX Phantom App
 # kelly.brazil@threatx.com
@@ -233,7 +234,7 @@ class ThreatxConnector(BaseConnector):
         # BaseConnector will create a textual message based off of the summary dictionary
         return action_result.set_status(phantom.APP_SUCCESS)
 
-    def _handle_new_blacklist_ip(self, param):
+    def _handle_new_denylist_ip(self, param):
 
         self.save_progress("In action handler for: {0}".format(self.get_action_identifier()))
 
@@ -269,7 +270,7 @@ class ThreatxConnector(BaseConnector):
         # BaseConnector will create a textual message based off of the summary dictionary
         return action_result.set_status(phantom.APP_SUCCESS)
 
-    def _handle_remove_blacklist_ip(self, param):
+    def _handle_remove_denylist_ip(self, param):
 
         self.save_progress("In action handler for: {0}".format(self.get_action_identifier()))
 
@@ -301,7 +302,7 @@ class ThreatxConnector(BaseConnector):
         # BaseConnector will create a textual message based off of the summary dictionary
         return action_result.set_status(phantom.APP_SUCCESS)
 
-    def _handle_new_whitelist_ip(self, param):
+    def _handle_new_allowlist_ip(self, param):
 
         self.save_progress("In action handler for: {0}".format(self.get_action_identifier()))
 
@@ -337,7 +338,7 @@ class ThreatxConnector(BaseConnector):
         # BaseConnector will create a textual message based off of the summary dictionary
         return action_result.set_status(phantom.APP_SUCCESS)
 
-    def _handle_remove_whitelist_ip(self, param):
+    def _handle_remove_allowlist_ip(self, param):
 
         self.save_progress("In action handler for: {0}".format(self.get_action_identifier()))
 
@@ -596,17 +597,17 @@ class ThreatxConnector(BaseConnector):
         elif action_id == 'unblock_ip':
             ret_val = self._handle_unblock_ip(param)
 
-        elif action_id == 'new_blacklist_ip':
-            ret_val = self._handle_new_blacklist_ip(param)
+        elif action_id == 'new_denylist_ip':
+            ret_val = self._handle_new_denylist_ip(param)
 
-        elif action_id == 'remove_blacklist_ip':
-            ret_val = self._handle_remove_blacklist_ip(param)
+        elif action_id == 'remove_denylist_ip':
+            ret_val = self._handle_remove_denylist_ip(param)
 
-        elif action_id == 'new_whitelist_ip':
-            ret_val = self._handle_new_whitelist_ip(param)
+        elif action_id == 'new_allowlist_ip':
+            ret_val = self._handle_new_allowlist_ip(param)
 
-        elif action_id == 'remove_whitelist_ip':
-            ret_val = self._handle_remove_whitelist_ip(param)
+        elif action_id == 'remove_allowlist_ip':
+            ret_val = self._handle_remove_allowlist_ip(param)
 
         elif action_id == 'get_entities':
             ret_val = self._handle_get_entities(param)
@@ -706,8 +707,9 @@ class ThreatxConnector(BaseConnector):
 
 if __name__ == '__main__':
 
-    import pudb
     import argparse
+
+    import pudb
 
     pudb.set_trace()
 
@@ -733,7 +735,7 @@ if __name__ == '__main__':
         try:
             login_url = ThreatxConnector._get_phantom_base_url() + '/login'
 
-            print ("Accessing the Login page")
+            print("Accessing the Login page")
             r = requests.get(login_url, verify=False)
             csrftoken = r.cookies['csrftoken']
 
@@ -746,11 +748,11 @@ if __name__ == '__main__':
             headers['Cookie'] = 'csrftoken=' + csrftoken
             headers['Referer'] = login_url
 
-            print ("Logging into Platform to get the session id")
+            print("Logging into Platform to get the session id")
             r2 = requests.post(login_url, verify=False, data=data, headers=headers)
             session_id = r2.cookies['sessionid']
         except Exception as e:
-            print ("Unable to get session id from the platform. Error: " + str(e))
+            print("Unable to get session id from the platform. Error: " + str(e))
             exit(1)
 
     with open(args.input_test_json) as f:
@@ -766,6 +768,6 @@ if __name__ == '__main__':
             connector._set_csrf_info(csrftoken, headers['Referer'])
 
         ret_val = connector._handle_action(json.dumps(in_json), None)
-        print (json.dumps(json.loads(ret_val), indent=4))
+        print(json.dumps(json.loads(ret_val), indent=4))
 
     exit(0)


### PR DESCRIPTION
As discussed with @mattsayar-splunk on slack, for now, we do not need to release the app with those changes. We will remove a biased name from the app and merge MR into the next.
We will release the app in the future when contributors submit the new code changes.
Not fixing other static job failures as it is related to py2 and we are not going to release this app.